### PR TITLE
Refactor reactor.seconds usage in core_commands/game.py. (Issue #27)

### DIFF
--- a/piqueserver/core_commands/game.py
+++ b/piqueserver/core_commands/game.py
@@ -1,6 +1,7 @@
 import math
 import re
-from twisted.internet import reactor
+import time
+
 from piqueserver.config import cast_duration
 from pyspades.common import prettify_timespan
 from piqueserver.commands import (
@@ -17,7 +18,7 @@ def get_time_limit(connection):
     if advance_call is None:
         return 'No time limit set'
     left = int(
-        math.ceil((advance_call.getTime() - reactor.seconds()) / 60.0))
+        math.ceil((advance_call.getTime() - time.time()) / 60.0))
     return 'There are %s minutes left' % left
 
 


### PR DESCRIPTION
reactor.seconds is replaced with time.time.